### PR TITLE
feat: prefer provided thumbnails in layout

### DIFF
--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -96,6 +96,7 @@ function _shuffleArray<T>(array: T[]): T[] {
 interface Game {
   id: string;
   title: string;
+  thumbnail?: string;
 }
 
 export function createOptimalLayout(games: Game[], maxItems: number = 24): LayoutRow[] {
@@ -137,8 +138,8 @@ export function createOptimalLayout(games: Game[], maxItems: number = 24): Layou
 
     if (!game) continue;
 
-    // First, get a random thumbnail to see what orientation we actually have
-    const thumbnail = getUniqueThumbnail();
+    // Determine the thumbnail to use, preferring the game's own if provided
+    const thumbnail = game.thumbnail || getUniqueThumbnail();
     const dimensions = getImageDimensionsFromPath(thumbnail);
 
     // Now determine if this orientation works with our current row


### PR DESCRIPTION
## Summary
- allow createOptimalLayout to use a game's own thumbnail before falling back to a placeholder
- compute image dimensions from the selected thumbnail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 276 problems)*

------
https://chatgpt.com/codex/tasks/task_b_68af059e24a48326b0040e2e780b941c