### PR TITLE
Add Vitest tests for game utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -33,6 +34,7 @@
     "postcss": "^8.5.6",
     "postcss-preset-env": "^9.4.0",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.1"
   }
 }

--- a/tests/games.test.ts
+++ b/tests/games.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getGameById, getGamesByCategory } from '@/lib/games';
+
+describe('getGameById', () => {
+  it('returns the game for an existing id', () => {
+    const game = getGameById('flappy-dwb');
+    expect(game).toBeDefined();
+    expect(game?.id).toBe('flappy-dwb');
+  });
+
+  it('returns undefined for a non-existent id', () => {
+    const game = getGameById('non-existent-id');
+    expect(game).toBeUndefined();
+  });
+});
+
+describe('getGamesByCategory', () => {
+  it('returns games for an existing category', () => {
+    const games = getGamesByCategory('Strategy');
+    expect(games.length).toBeGreaterThan(0);
+    for (const game of games) {
+      expect(game.category).toBe('Strategy');
+    }
+  });
+
+  it('returns an empty array for a non-existent category', () => {
+    const games = getGamesByCategory('NonExistent');
+    expect(games).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest test runner and configuration
- test `getGameById` and `getGamesByCategory`

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af05bb2b188326809f57769525f9df