### PR TITLE
Fix abduction game thumbnail filename

### DIFF
--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -68,7 +68,7 @@ export const games: Game[] = [
     difficulty: 'Medium',
     highScore: 0,
     isAvailable: true,
-    thumbnail: '/Thumbnails/ABDUCXTION.jpg',
+    thumbnail: '/Thumbnails/ABDUCTION.jpg',
     category: 'Strategy',
     estimatedPlayTime: '8-20 minutes',
     isPopular: false,


### PR DESCRIPTION
## Summary
- correct typo in abduction game thumbnail path
- rename thumbnail image to match new path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 276 problems (190 errors, 86 warnings))*

------
https://chatgpt.com/codex/tasks/task_b_68af05a025008326a17c9b2979442864