### PR TITLE
feat: add theater mode game page

### DIFF
--- a/public/games/flappy-dwb/index.html
+++ b/public/games/flappy-dwb/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Flappy DWB</title>
+<style>
+  html, body { margin:0; padding:0; height:100%; background:#000; display:flex; align-items:center; justify-content:center; }
+  canvas { background:#222; display:block; }
+</style>
+</head>
+<body>
+<canvas id="game" width="480" height="640"></canvas>
+<script>
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+let y = canvas.height / 2; let velocity = 0; const gravity = 0.5;
+function loop() {
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0,0,canvas.width,canvas.height);
+  velocity += gravity;
+  y += velocity;
+  if (y > canvas.height - 20) { y = canvas.height - 20; velocity = -10; }
+  ctx.fillStyle = '#0f0';
+  ctx.fillRect(100, y, 40, 40);
+  requestAnimationFrame(loop);
+}
+loop();
+canvas.addEventListener('click', () => velocity = -8);
+</script>
+</body>
+</html>

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { getGameById, getGamesByCategory, getAvailableGames } from '@/lib/games';
 import { Header } from '@/components/Header';
 import Sidebar from '@/components/Sidebar';
 import GameCarousel from '@/components/GameCarousel';
-import { ArrowLeft, Play, Star, Clock } from 'lucide-react';
+import { ArrowLeft, Star, Clock } from 'lucide-react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useSidebar } from '@/contexts/SidebarContext';
@@ -15,6 +16,16 @@ export default function GamePage() {
   const gameId = params.id as string;
   const game = getGameById(gameId);
   const { isCollapsed } = useSidebar();
+  const [gameUrl, setGameUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `/games/${gameId}/index.html`;
+    fetch(url, { method: 'HEAD' })
+      .then(res => {
+        if (res.ok) setGameUrl(url);
+      })
+      .catch(() => {});
+  }, [gameId]);
 
   // Get related games (same category, excluding current game)
   const relatedGames = getGamesByCategory(game?.category || '')
@@ -57,84 +68,76 @@ export default function GamePage() {
       <Header />
       <div className="flex">
         <Sidebar />
-        <main className="flex-1 transition-all duration-300" style={{
-          marginLeft: isCollapsed ? 'clamp(56px, 4vw, 80px)' : 'clamp(240px, 16vw, 320px)',
-          padding: 'clamp(1rem, 2vw, 2rem)',
-          width: `calc(100vw - ${isCollapsed ? 'clamp(56px, 4vw, 80px)' : 'clamp(240px, 16vw, 320px)'})`,
-        }}>
+        <main
+          className="flex-1 transition-all duration-300"
+          style={{
+            marginLeft: isCollapsed ? 'clamp(56px, 4vw, 80px)' : 'clamp(240px, 16vw, 320px)',
+            padding: 'clamp(1rem, 2vw, 2rem)',
+            width: `calc(100vw - ${isCollapsed ? 'clamp(56px, 4vw, 80px)' : 'clamp(240px, 16vw, 320px)'})`,
+          }}
+        >
           <div className="container">
-            {/* Back Button */}
-            <Link href="/" className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6"
+            >
               <ArrowLeft size={20} />
               Back to Games
             </Link>
 
-                         {/* Game Details */}
-             <div className="grid grid-cols-1 xl:grid-cols-2 gap-8">
-               {/* Game Image */}
-               <div className="relative bg-muted rounded-lg overflow-hidden" style={{
-                 height: 'clamp(300px, 40vh, 600px)',
-                 minHeight: '300px',
-               }}>
-                 <Image
-                   src={game.thumbnail}
-                   alt={game.title}
-                   fill
-                   className="object-cover"
-                   sizes="(max-width: 1280px) 100vw, 50vw"
-                 />
-               </div>
+            <div
+              className="relative w-full bg-black rounded-lg overflow-hidden flex items-center justify-center mb-8"
+              style={{ height: 'clamp(400px, 70vh, 900px)' }}
+            >
+              {gameUrl ? (
+                <iframe src={gameUrl} className="w-full h-full border-0" allowFullScreen />
+              ) : (
+                <Image
+                  src={game.thumbnail}
+                  alt={game.title}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 1280px) 100vw, 50vw"
+                />
+              )}
+            </div>
+            {!gameUrl && (
+              <p className="text-center text-muted-foreground mb-8">Game coming soon!</p>
+            )}
 
-                             {/* Game Info */}
-               <div className="space-y-6">
-                 <div>
-                   <h1 className="font-bold mb-2" style={{ fontSize: 'clamp(2rem, 4vw, 3.5rem)' }}>{game.title}</h1>
-                   <p className="text-muted-foreground" style={{ fontSize: 'clamp(1rem, 1.5vw, 1.25rem)' }}>{game.description}</p>
-                 </div>
+            <h1
+              className="font-bold mb-2"
+              style={{ fontSize: 'clamp(2rem, 4vw, 3.5rem)' }}
+            >
+              {game.title}
+            </h1>
+            <p
+              className="text-muted-foreground mb-6"
+              style={{ fontSize: 'clamp(1rem, 1.5vw, 1.25rem)' }}
+            >
+              {game.description}
+            </p>
 
-                {/* Game Meta */}
-                <div className="flex flex-wrap gap-4">
-                  <div className="flex items-center gap-2">
-                    <Star className="text-yellow-400" />
-                    <span>High Score: {game.highScore.toLocaleString()}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <Clock className="text-muted-foreground" />
-                    <span>{game.estimatedPlayTime}</span>
-                  </div>
-                </div>
-
-                {/* Tags */}
-                <div className="flex flex-wrap gap-2">
-                  <span className="px-3 py-1 bg-primary text-primary-foreground rounded-full text-sm font-medium">
-                    {game.category}
-                  </span>
-                  <span className="px-3 py-1 bg-secondary text-secondary-foreground rounded-full text-sm font-medium">
-                    {game.difficulty}
-                  </span>
-                </div>
-
-                                 {/* Play Button */}
-                 <button className="w-full pixel-button flex items-center justify-center gap-2" style={{
-                   padding: 'clamp(12px, 2vw, 20px) clamp(16px, 3vw, 32px)',
-                   fontSize: 'clamp(1rem, 1.5vw, 1.25rem)',
-                 }}>
-                   <Play size={24} />
-                   Play Now
-                 </button>
-
-                {/* Additional Info */}
-                <div className="bg-muted p-4 rounded-lg">
-                  <h3 className="font-bold mb-2">About this game</h3>
-                  <p className="text-muted-foreground text-sm">
-                    This is a placeholder for game-specific information. In a real implementation,
-                    this would contain detailed game instructions, controls, and other relevant information.
-                  </p>
-                </div>
+            <div className="flex flex-wrap gap-4 mb-6">
+              <div className="flex items-center gap-2">
+                <Star className="text-yellow-400" />
+                <span>High Score: {game.highScore.toLocaleString()}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="text-muted-foreground" />
+                <span>{game.estimatedPlayTime}</span>
               </div>
             </div>
 
-            {/* Related Games */}
+            <div className="flex flex-wrap gap-2 mb-12">
+              <span className="px-3 py-1 bg-primary text-primary-foreground rounded-full text-sm font-medium">
+                {game.category}
+              </span>
+              <span className="px-3 py-1 bg-secondary text-secondary-foreground rounded-full text-sm font-medium">
+                {game.difficulty}
+              </span>
+            </div>
+
             {gamesToShow.length > 0 && (
               <div className="mt-12">
                 <h2 className="text-2xl font-bold mb-6">


### PR DESCRIPTION
## Summary
- display games in a large theater-style view
- autostart available games without an extra play button

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: 276 problems)*

------
https://chatgpt.com/codex/tasks/task_b_68af0f7050688326933262158c48c16e